### PR TITLE
410 error fix

### DIFF
--- a/src/Libraries/Nop.Core/Infrastructure/CustomMiddlewareStartup.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/CustomMiddlewareStartup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Nop.Core.Infrastructure; 
 using Microsoft.AspNetCore.Http;
 using System.Linq;
+using System;
 
 namespace Nop.Web.Infrastructure
 {

--- a/src/Libraries/Nop.Core/Infrastructure/CustomMiddlewareStartup.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/CustomMiddlewareStartup.cs
@@ -1,0 +1,47 @@
+// Nop.Web/Infrastructure/CustomMiddlewareStartup.cs
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nop.Core.Infrastructure; 
+using Microsoft.AspNetCore.Http;
+using System.Linq;
+
+namespace Nop.Web.Infrastructure
+{
+    public class CustomMiddlewareStartup : INopStartup // <-- Implement the interface
+    {
+        
+        /// Gets order of this startup configuration implementation
+        
+        public int Order => 105; // Run after static files
+
+    
+        public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            // No services to configure
+        }
+
+       
+        /// Configure the using of added middleware
+       
+        /// <param name="application">Builder for configuring an application's request pipeline</param>
+        public void Configure(IApplicationBuilder application)
+        {
+            // Add the custom middleware to the pipeline
+            application.Use(async (context, next) =>
+            {
+                var goneUrls = new[] { "/water-heaters-delivered-installed-within-24hours" };
+
+                if (goneUrls.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase))
+                {
+                    context.Response.StatusCode = StatusCodes.Status410Gone;
+                    await context.Response.WriteAsync("410 Gone - This page has been permanently removed.");
+                    return;
+                }
+
+                await next();
+            });
+        }
+    }
+}

--- a/src/Presentation/Nop.Web/Startup.cs
+++ b/src/Presentation/Nop.Web/Startup.cs
@@ -3,9 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nop.Web.Framework.Infrastructure.Extensions;
-using System; 
-using System.Linq; 
-using Microsoft.AspNetCore.Http;
+
 
 namespace Nop.Web
 {
@@ -56,21 +54,6 @@ namespace Nop.Web
         {
             application.ConfigureRequestPipeline();
             application.StartEngine();
-
-            // 410 error for removed pages
-            application.Use(async (context, next) =>
-{
-    var goneUrls = new[] { "/water-heaters-delivered-installed-within-24hours" };
-
-    if (goneUrls.Contains(context.Request.Path.Value, StringComparer.OrdinalIgnoreCase))
-    {
-        context.Response.StatusCode = StatusCodes.Status410Gone;
-        await context.Response.WriteAsync("410 Gone - This page has been permanently removed.");
-        return;
-    }
-
-    await next();
-});
         }
 
     }


### PR DESCRIPTION
Added 410 Gone response for removed water heaters page

Implemented custom middleware to return HTTP 410 status for the specific URL /water-heaters-delivered-installed-within-24hours instead of the default 404.