### PR TITLE
❯ Fixed a 500 error on the Stearns & Foster Rockwell Plush page cause…

### DIFF
--- a/src/Plugins/AbcWarehouse.Plugin.Widgets.UniFi/Components/UniFiViewComponent.cs
+++ b/src/Plugins/AbcWarehouse.Plugin.Widgets.UniFi/Components/UniFiViewComponent.cs
@@ -95,10 +95,11 @@ namespace AbcWarehouse.Plugin.Widgets.UniFi.Components
                         if (isMattress)
                         {
                             var abcMattressModel = _abcMattressModelService.GetAbcMattressModelByProductId(productId);
-                            // just to keep it simple, grab the first entry
-                            var abcMattressEntry = _abcMattressEntryService.GetAbcMattressEntriesByModelId(abcMattressModel.Id).First();
-                            
-                            abcItemNumber = abcMattressEntry?.ItemNo;
+                            if (abcMattressModel != null)
+                            {
+                                var abcMattressEntry = _abcMattressEntryService.GetAbcMattressEntriesByModelId(abcMattressModel.Id).FirstOrDefault();
+                                abcItemNumber = abcMattressEntry?.ItemNo;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
…d by the UniFi widget crashing when a mattress model has no entries.